### PR TITLE
Added Label to Dockerfile for github packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM golang:alpine as build
+LABEL org.opencontainers.image.source = "https://github.com/jay-dee7/OpenRegistry"
 
 WORKDIR /root/openregistry
 


### PR DESCRIPTION
Signed-off-by: jay-dee7 <jasdeepsingh.uppal@gmail.com>

---

this PR adds a label to Dockerfile so that Github Packages can see the container image as a package for this repository
